### PR TITLE
fix: Add sourceAccount and sourceAccountIdentifier fields to saveBills

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,8 @@ async function start(fields) {
 
   log('info', 'Saving data to Cozy')
   await saveBills(documents, fields, {
+    sourceAccount: this.accountId,
+    sourceAccountIdentifier: fields.login,
     identifiers: [vendor],
     contentType: 'application/pdf'
   })


### PR DESCRIPTION
Removes the warnings in logs and allow for better deduplication strategy.