### PR TITLE
fix: Fix regex for fileurl

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,10 +93,8 @@ async function parseDocuments($) {
   const orders = []
   $('.mythomann-order-teaser').each((i, el) => {
     const details = $(el)
-      .find('.mythomann-order-teaser__details-wrapper')
-      .html()
-      .match(/a href="(.*)>/g)[0]
-      .split('"')[1]
+      .find('.mythomann-order-teaser__details-wrapper > a')
+      .attr('href')
     const billsData = $(el)
       .find('.mythomann-order-teaser__detail')
       .text()


### PR DESCRIPTION
Thomann adds a class on their html tag `a`, leading the regex to fail when searching for the fileurl. This PR fixes it.